### PR TITLE
Fixed behaviour on Linux

### DIFF
--- a/TML.Patcher/Common/ConfigurationFile.cs
+++ b/TML.Patcher/Common/ConfigurationFile.cs
@@ -9,8 +9,8 @@ namespace TML.Patcher.Common
         public const string UndefinedPath = "undefined";
         public const string WindowsDefault = @"%UserProfile%\Documents\My Games\Terraria\ModLoader\Mods";
         public const string MacDefault = @"~/Library/Application support/Terraria/ModLoader/Mods";
-        public const string LinuxDefault1 = @"~/.local/share/Terraria/ModLoader/Mods";
-        public const string LinuxDefault2 = @"$XDG_DATA_HOME/Terraria/ModLoader/Mods";
+        public const string LinuxDefault1 = @"%HOME%/.local/share/Terraria/ModLoader/Mods";
+        public const string LinuxDefault2 = @"%XDG_DATA_HOME%/Terraria/ModLoader/Mods";
 
         public static string FilePath { get; private set; }
 

--- a/TML.Patcher/Common/ConfigurationFile.cs
+++ b/TML.Patcher/Common/ConfigurationFile.cs
@@ -13,6 +13,8 @@ namespace TML.Patcher.Common
         public const string LinuxDefault2 = @"%XDG_DATA_HOME%/Terraria/ModLoader/Mods";
 
         public static string FilePath { get; private set; }
+        
+        public bool ShowIlSpyCmdInstallPrompt { get; set; }
 
         public string ModsPath { get; set; }
 
@@ -37,6 +39,7 @@ namespace TML.Patcher.Common
 
             ConfigurationFile config = new()
             {
+                ShowIlSpyCmdInstallPrompt = true,
                 ExtractPath = Path.Combine(Program.EXEPath, "Extracted"),
                 DecompilePath = Path.Combine(Program.EXEPath, "Decompiled"),
                 ReferencesPath = Path.Combine(Program.EXEPath, "References"),
@@ -79,6 +82,7 @@ namespace TML.Patcher.Common
         {
             ConfigurationFile config = new()
             {
+                ShowIlSpyCmdInstallPrompt = Program.Configuration.ShowIlSpyCmdInstallPrompt,
                 ModsPath = Program.Configuration.ModsPath,
                 ExtractPath = Program.Configuration.ExtractPath,
                 DecompilePath = Program.Configuration.DecompilePath,


### PR DESCRIPTION
Implemented some fixes to make the tool work on Linux as well.

I slightly changed the default paths for Linux to properly utilize/encode environment variables and refined the handling for the ilspycmd installation process a bit to work on unix-based systems.

[I also added a yes/no prompt to the ilspycmd installation process and ensured that the prompt (and the installation) is only executed on the first startup of the tool]


Tested on GNU/Linux Gentoo (Kernel 5.10.27-gentoo)